### PR TITLE
Fix simplified subsumption for ghc-9

### DIFF
--- a/src/System/IOManager.hs
+++ b/src/System/IOManager.hs
@@ -51,7 +51,7 @@ newtype IOManager = IOManager {
   }
 
 associateWithIOCP :: forall hole. IOManager -> hole -> IO ()
-associateWithIOCP = associateWithIOManager
+associateWithIOCP = \x -> associateWithIOManager x
 #endif
 
 type AssociateWithIOCP = IOManager


### PR DESCRIPTION
Hi, this allows this repository to build with ghc-9.0 due to the simplified subsumption change.